### PR TITLE
Prevent Supabase error message leak by returning a generic error to the client.

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -20,7 +20,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const { data, error } = await supabase.auth.signInWithPassword({ email, password });
 
     if (error) {
-      return NextResponse.json({ error: error.message, success: false }, { status: 401 });
+      // Log the actual error for debugging (server-side only)
+      console.error("Login authentication error:", error.message);
+      
+      // Return generic error message to client
+      return NextResponse.json({ error: "Invalid email or password", success: false }, { status: 401 });
     }
 
     if (data.user) {


### PR DESCRIPTION
Prevent Supabase error message leak by returning a generic error to the client.

---
<a href="https://cursor.com/background-agent?bcId=bc-45636ba2-5fcf-4534-9e39-15ff4c387e0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-45636ba2-5fcf-4534-9e39-15ff4c387e0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

