### PR TITLE
Add CSRF verification to API routes

### DIFF
--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,8 +1,13 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { verifyCsrfToken } from "@/lib/security";
 
-export async function POST() {
+export async function POST(request: NextRequest) {
   try {
+    if (!verifyCsrfToken(request)) {
+      return NextResponse.json({ error: "Invalid request origin" }, { status: 403 });
+    }
+
     const supabase = await createClient();
 
     await supabase.auth.signOut();

--- a/app/api/cafe/create/route.ts
+++ b/app/api/cafe/create/route.ts
@@ -3,9 +3,14 @@ import { createClient } from "@/lib/supabase/server";
 import { cafeSchema } from "@/lib/schema";
 import { TablesInsert } from "@/types/db";
 import { slugify } from "@/lib/utils";
+import { verifyCsrfToken } from "@/lib/security";
 
 export async function POST(request: NextRequest) {
   try {
+    if (!verifyCsrfToken(request)) {
+      return NextResponse.json({ error: "Invalid request origin" }, { status: 403 });
+    }
+
     const supabase = await createClient();
 
     const {

--- a/app/api/category/create/route.ts
+++ b/app/api/category/create/route.ts
@@ -1,9 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { categorySchema } from "@/lib/schema";
+import { verifyCsrfToken } from "@/lib/security";
 
 export async function POST(request: NextRequest) {
   try {
+    if (!verifyCsrfToken(request)) {
+      return NextResponse.json({ error: "Invalid request origin" }, { status: 403 });
+    }
+
     const supabase = await createClient();
     const {
       data: { user },
@@ -39,7 +44,12 @@ export async function POST(request: NextRequest) {
             : validationResult.data.sort_order,
     };
 
-    const { data: cafe, error: cafeError } = await supabase.from("cafes").select("id").eq("id", cafe_id).eq("user_id", user.id).single();
+    const { data: cafe, error: cafeError } = await supabase
+      .from("cafes")
+      .select("id")
+      .eq("id", cafe_id)
+      .eq("user_id", user.id)
+      .single();
 
     if (cafeError || !cafe) {
       return NextResponse.json({ error: "Cafe not found or access denied" }, { status: 404 });

--- a/app/api/category/update/route.ts
+++ b/app/api/category/update/route.ts
@@ -1,9 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { categorySchema } from "@/lib/schema";
+import { verifyCsrfToken } from "@/lib/security";
 
 export async function PUT(request: NextRequest) {
   try {
+    if (!verifyCsrfToken(request)) {
+      return NextResponse.json({ error: "Invalid request origin" }, { status: 403 });
+    }
+
     const supabase = await createClient();
     const {
       data: { user },
@@ -37,13 +42,24 @@ export async function PUT(request: NextRequest) {
             : validationResult.data.sort_order,
     };
 
-    const { data: existingCategory, error: fetchError } = await supabase.from("categories").select("id, cafe_id").eq("id", id).eq("user_id", user.id).single();
+    const { data: existingCategory, error: fetchError } = await supabase
+      .from("categories")
+      .select("id, cafe_id")
+      .eq("id", id)
+      .eq("user_id", user.id)
+      .single();
 
     if (fetchError || !existingCategory) {
       return NextResponse.json({ error: "Category not found or access denied" }, { status: 404 });
     }
 
-    const { data: category, error: updateError } = await supabase.from("categories").update(processedData).eq("id", id).eq("user_id", user.id).select().single();
+    const { data: category, error: updateError } = await supabase
+      .from("categories")
+      .update(processedData)
+      .eq("id", id)
+      .eq("user_id", user.id)
+      .select()
+      .single();
 
     if (updateError) {
       return NextResponse.json({ error: "Failed to update category" }, { status: 500 });

--- a/app/api/product/update/route.ts
+++ b/app/api/product/update/route.ts
@@ -1,8 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { verifyCsrfToken } from "@/lib/security";
 
 export async function PUT(request: NextRequest) {
   try {
+    if (!verifyCsrfToken(request)) {
+      return NextResponse.json({ error: "Invalid request origin" }, { status: 403 });
+    }
+
     const supabase = await createClient();
     const {
       data: { user },
@@ -26,7 +31,13 @@ export async function PUT(request: NextRequest) {
       user_id: user.id,
     };
 
-    const { data: product, error: updateError } = await supabase.from("products").update(updateDataWithUserId).eq("id", id).eq("user_id", user.id).select().single();
+    const { data: product, error: updateError } = await supabase
+      .from("products")
+      .update(updateDataWithUserId)
+      .eq("id", id)
+      .eq("user_id", user.id)
+      .select()
+      .single();
 
     if (updateError) {
       return NextResponse.json({ error: "Failed to update product" }, { status: 500 });

--- a/app/api/storage/delete/route.ts
+++ b/app/api/storage/delete/route.ts
@@ -1,8 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { verifyCsrfToken } from "@/lib/security";
 
 export async function DELETE(request: NextRequest) {
   try {
+    if (!verifyCsrfToken(request)) {
+      return NextResponse.json({ error: "Invalid request origin" }, { status: 403 });
+    }
+
     const supabase = await createClient();
 
     const {


### PR DESCRIPTION
## Summary
- import and call `verifyCsrfToken` in logout, cafe, category, product, and storage API handlers
- return 403 for requests with an invalid origin header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: linter errors in unrelated files)*
- `npx biome check app/api/auth/logout/route.ts app/api/cafe/create/route.ts app/api/cafe/update/route.ts app/api/category/create/route.ts app/api/category/update/route.ts app/api/category/[id]/route.ts app/api/category/sort-order/route.ts app/api/product/create/route.ts app/api/product/update/route.ts app/api/product/[id]/route.ts app/api/storage/delete/route.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bddac1e7ec83328b7fccc53035784a