### PR TITLE
feat: log cookie set errors

### DIFF
--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -15,7 +15,10 @@ export async function createClient() {
       setAll(cookiesToSet) {
         try {
           cookiesToSet.forEach(({ name, value, options }) => cookieStore.set(name, value, options));
-        } catch {}
+        } catch (error) {
+          console.error("Failed to set cookies:", error);
+          throw error;
+        }
       },
     },
   });


### PR DESCRIPTION
## Summary
- log cookie set errors when establishing Supabase server client

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint lib/supabase/server.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bddad9f314833287f4840eb80d55fd