### PR TITLE
Add public cafe cache invalidation across multiple API routes

### DIFF
--- a/app/api/cafe/update/route.ts
+++ b/app/api/cafe/update/route.ts
@@ -4,7 +4,7 @@ import { http } from "@/lib/http";
 import { cafeSchema } from "@/lib/schema";
 import { verifyCsrfToken } from "@/lib/security";
 import { createClient } from "@/lib/supabase/server";
-import { invalidateUserCafesCache } from "@/lib/redis";
+import { invalidateUserCafesCache, invalidatePublicCafeCache } from "@/lib/redis";
 
 export async function PUT(request: NextRequest) {
   try {
@@ -82,6 +82,12 @@ export async function PUT(request: NextRequest) {
     }
 
     invalidateUserCafesCache(user.id);
+
+    // Invalidate public cafe cache for both old and new slugs
+    if (existingCafe.slug !== finalSlug) {
+      invalidatePublicCafeCache(existingCafe.slug);
+    }
+    invalidatePublicCafeCache(finalSlug);
 
     return NextResponse.json(data, { status: 200 });
   } catch (_error) {

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -7,6 +7,7 @@ export const redis = new Redis({
 
 export const getCacheKeys = {
   cafes: (userId: string) => `cafes:user:${userId}`,
+  publicCafe: (slug: string) => `public:cafe:${slug}`,
 };
 
 export async function invalidateUserCafesCache(userId: string) {
@@ -15,5 +16,14 @@ export async function invalidateUserCafesCache(userId: string) {
     await redis.del(cacheKey);
   } catch (error) {
     console.warn("Failed to invalidate cafes cache:", error);
+  }
+}
+
+export async function invalidatePublicCafeCache(slug: string) {
+  try {
+    const cacheKey = getCacheKeys.publicCafe(slug);
+    await redis.del(cacheKey);
+  } catch (error) {
+    console.warn("Failed to invalidate public cafe cache:", error);
   }
 }


### PR DESCRIPTION
- Introduced `invalidatePublicCafeCache` function to manage cache invalidation for public cafes.
- Updated cafe, category, and product API routes to invalidate public cafe cache upon creation, update, and deletion.
- Enhanced data fetching in category and product routes to include cafe slugs for accurate cache management.
- Implemented caching logic in the public cafe route to improve performance by utilizing Redis for cached responses.