### PR TITLE
Update ProductForm to set default price to 0 instead of undefined

### DIFF
--- a/components/product/ProductForm.tsx
+++ b/components/product/ProductForm.tsx
@@ -55,7 +55,7 @@ const ProductForm = forwardRef<ProductFormRef, Props>((props, ref) => {
     return {
       name: "",
       description: "",
-      price: undefined,
+      price: 0,
       image_url: "",
       is_available: true,
       category_id: props.categoryId,


### PR DESCRIPTION
- Changed the default value of the price field in ProductForm from undefined to 0 for better initialization and to prevent potential issues with undefined values.