### PR TITLE
Add debug logging in PublicMenuRepository for base URL visibility

### DIFF
--- a/lib/repositories/public-menu-repository.ts
+++ b/lib/repositories/public-menu-repository.ts
@@ -38,6 +38,8 @@ export class PublicMenuRepository extends BaseRepository {
   protected readonly baseUrl = `${nextPublicBaseUrl}/api/public/cafe`;
 
   async getMenuBySlug(slug: string) {
+    console.log("Base URL", this.baseUrl);
+
     return await this.get<PublicMenuData>(`/${slug}`);
   }
 }


### PR DESCRIPTION
- Introduced a console log statement in the getMenuBySlug method to output the base URL, aiding in debugging and traceability of API requests.