### PR TITLE
Update base URL in PublicMenuRepository to use environment variable

### DIFF
--- a/lib/repositories/public-menu-repository.ts
+++ b/lib/repositories/public-menu-repository.ts
@@ -1,3 +1,4 @@
+import { nextPublicBaseUrl } from "@/lib/env";
 import { BaseRepository } from "@/lib/repositories/base-repository";
 
 export interface PublicProduct {
@@ -34,9 +35,11 @@ export interface PublicMenuData {
 }
 
 export class PublicMenuRepository extends BaseRepository {
-  protected readonly baseUrl = `/api/public/cafe`;
+  protected readonly baseUrl = `${nextPublicBaseUrl}/api/public/cafe`;
 
   async getMenuBySlug(slug: string) {
+    console.log("Base URL", this.baseUrl);
+
     return await this.get<PublicMenuData>(`/${slug}`);
   }
 }


### PR DESCRIPTION
- Changed the base URL in PublicMenuRepository to utilize the nextPublicBaseUrl environment variable for better configuration management.
- Added a console log statement in the getMenuBySlug method to display the base URL for debugging purposes.